### PR TITLE
Refactor:

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -2,7 +2,7 @@ use aide::axum::routing::get_with;
 use aide::axum::{ApiRouter, IntoApiResponse};
 use axum::body::Body;
 use axum::http::{HeaderValue, Response, StatusCode};
-use std::fs::read;
+use tracing::error;
 
 pub fn get_routes() -> Vec<(&'static str, &'static str, &'static str, &'static str)> {
     // vec of file paths, routes, tags, and descriptions
@@ -43,10 +43,9 @@ pub fn get_routes() -> Vec<(&'static str, &'static str, &'static str, &'static s
 
 pub fn create_router() -> ApiRouter {
     let routes = get_routes();
-
     let mut router = ApiRouter::new();
-    for (file_path, route, tag, _description) in routes {
-        let description = file_path;
+
+    for (file_path, route, tag, description) in routes {
         let desc = if description.is_empty() {
             file_path
         } else {
@@ -65,16 +64,19 @@ pub fn create_router() -> ApiRouter {
 }
 
 pub async fn get_handler(file_path: &str) -> impl IntoApiResponse {
-    match read(file_path) {
-        Ok(contents) => {
-            let mime_type = infer::get(&contents)
-                .map_or("application/octet-stream".to_string(), |typ| {
-                    typ.mime_type().to_string()
-                });
-            build_response(contents, mime_type)
+    match read_file_and_detect_mime(file_path).await {
+        Ok((contents, mime_type)) => build_response(contents, mime_type),
+        Err(err) => {
+            error!("Error handling file {}: {:?}", file_path, err);
+            build_error_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal server error")
         }
-        Err(_) => build_error_response(StatusCode::NOT_FOUND, "File not found"),
     }
+}
+
+async fn read_file_and_detect_mime(file_path: &str) -> Result<(Vec<u8>, String), std::io::Error> {
+    let contents = tokio::fs::read(file_path).await?;
+    let mime_type = mime_guess::from_path(file_path).first_or_octet_stream().to_string();
+    Ok((contents, mime_type))
 }
 
 pub fn build_response(contents: Vec<u8>, mime_type: String) -> Response<Body> {

--- a/tests/asset_tests.rs
+++ b/tests/asset_tests.rs
@@ -121,7 +121,7 @@ mod tests {
 
         let response =
             askama_axum::IntoResponse::into_response(get_handler("assets/nonexistent.png").await);
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]


### PR DESCRIPTION
	- add new function, read_file_and_detect_mime to simplify get_handler
	- contents are read asynchronously using tokio::fs::read
	- changed mime_type detection logic to use simpler mime_guess::from_path instead of infer