### PR TITLE
fix: change default OAuth2 response type from token to code

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,7 +14,7 @@ pub(crate) static OAUTH2_SCOPE: Lazy<String> =
 pub(crate) static OAUTH2_RESPONSE_MODE: Lazy<String> =
     Lazy::new(|| std::env::var("OAUTH2_RESPONSE_MODE").unwrap_or("query".to_string()));
 pub(crate) static OAUTH2_RESPONSE_TYPE: Lazy<String> =
-    Lazy::new(|| std::env::var("OAUTH2_RESPONSE_TYPE").unwrap_or("token".to_string()));
+    Lazy::new(|| std::env::var("OAUTH2_RESPONSE_TYPE").unwrap_or("code".to_string()));
 
 // "__Host-" prefix are added to make cookies "host-only".
 pub(crate) static SESSION_COOKIE_NAME: &str = "__Host-SessionId";


### PR DESCRIPTION
Switch the default OAuth2 response type from implicit flow (token) to authorization code flow (code) for enhanced security and compliance with best practices.